### PR TITLE
refine-buffer-scheduling

### DIFF
--- a/src/WavPlayer.js
+++ b/src/WavPlayer.js
@@ -15,11 +15,12 @@ const WavPlayer = () => {
         const context = new AudioContext();
 
         const scheduleBuffers = () => {
-            while (audioStack.length) {
+            while (audioStack.length > 0 && audioStack[0].buffer !== undefined) {
                 const source = context.createBufferSource();
 
-                source.buffer = audioStack.shift();
+                const segment = audioStack.shift();
 
+                source.buffer = segment.buffer;
                 source.connect(context.destination);
 
                 if (nextTime == 0) {
@@ -50,7 +51,8 @@ const WavPlayer = () => {
                     return;
                 }
                 if (value && value.buffer) {
-                    let buffer;
+                    let buffer,
+                        segment;
 
                     if (rest !== null) {
                         buffer = concat(rest, value.buffer);
@@ -87,11 +89,14 @@ const WavPlayer = () => {
                         rest = null;
                     }
 
+                    segment = {};
+
+                    audioStack.push(segment);
+
                     context.decodeAudioData(wavify(buffer, numberOfChannels, sampleRate)).then((audioBuffer) => {
-                        audioStack.push(audioBuffer);
-                        if (audioStack.length) {
-                            scheduleBuffers();
-                        }
+                        segment.buffer = audioBuffer;
+
+                        scheduleBuffers();
                     });
                 }
 

--- a/src/WavPlayer.js
+++ b/src/WavPlayer.js
@@ -136,9 +136,9 @@ const WavPlayer = () => {
     }
 
     return {
-      play: url => play(url),
-      stop: () => hasCanceled_ = true
-  }
+        play: url => play(url),
+        stop: () => hasCanceled_ = true
+    }
 }
 
 export default WavPlayer;

--- a/src/WavPlayer.js
+++ b/src/WavPlayer.js
@@ -28,7 +28,7 @@ const WavPlayer = () => {
                 source.connect(context.destination);
 
                 if (nextTime == 0) {
-                    nextTime = currentTime + 0.3;  /// add 50ms latency to work well across systems - tune this if you like
+                    nextTime = currentTime + 0.3;  /// add 300ms latency to work well across systems - tune this if you like
                 }
 
                 let duration = source.buffer.duration;

--- a/src/wavify.js
+++ b/src/wavify.js
@@ -24,11 +24,11 @@ const wavify = (data, numberOfChannels, sampleRate) => {
 
     d.setUint32(16, 16, true);
     d.setUint16(20, 1, true);
-    d.setUint16(22, 1, true);
     d.setUint16(22, numberOfChannels, true);
     d.setUint32(24, sampleRate, true);
     d.setUint32(28, sampleRate * 1 * 2);
     d.setUint16(32, numberOfChannels * 2);
+    d.setUint16(34, 16, true);
 
     d.setUint8(36, 'd'.charCodeAt(0));
     d.setUint8(37, 'a'.charCodeAt(0));

--- a/src/wavify.js
+++ b/src/wavify.js
@@ -1,7 +1,7 @@
 import concat from './concat';
 
 // Write a proper WAVE header for the given buffer.
-const wavify = (data) => {
+const wavify = (data, numberOfChannels, sampleRate) => {
     const header = new ArrayBuffer(44);
 
     var d = new  DataView(header);
@@ -25,10 +25,10 @@ const wavify = (data) => {
     d.setUint32(16, 16, true);
     d.setUint16(20, 1, true);
     d.setUint16(22, 1, true);
-    d.setUint32(24, 11025, true);
-    d.setUint32(28, 11025 * 1 * 2);
-    d.setUint16(32, 1 * 2);
-    d.setUint16(34, 16, true);
+    d.setUint16(22, numberOfChannels, true);
+    d.setUint32(24, sampleRate, true);
+    d.setUint32(28, sampleRate * 1 * 2);
+    d.setUint16(32, numberOfChannels * 2);
 
     d.setUint8(36, 'd'.charCodeAt(0));
     d.setUint8(37, 'a'.charCodeAt(0));


### PR DESCRIPTION
Hi @revolunet, I added several things to ensure buffers are scheduled when they are actually needed.
- Buffers are now scheduled in the same order as they arrive.
- Buffers are now skipped if they arrive to late. (They have just been played with a delay before.)
- Buffers are only scheduled if they are really due to be played. Previously, in case the data arrived too fast, all the buffers were scheduled as they arrived and overwhelmed the audio thread.

Besides that the number of channels and the sample rate are not hard coded anymore.
